### PR TITLE
Update PCRE_DOWNLOAD_LINK from ftp.pcre.org to github.

### DIFF
--- a/MacClam.sh
+++ b/MacClam.sh
@@ -232,7 +232,7 @@ fi
 
 echo -n What is the latest version of pcre?...
 PCRE_VER=$(curl -s --connect-timeout 15  https://www.pcre.org/|grep 'is now at version '|grep -Eo '10\.[0-9]+')
-PCRE_DOWNLOAD_LINK="https://ftp.pcre.org/pub/pcre/pcre2-$PCRE_VER.tar.gz"
+PCRE_DOWNLOAD_LINK="https://github.com/PhilipHazel/pcre2/releases/download/pcre2-$PCRE_VER/pcre2-$PCRE_VER.tar.gz"
 
 if [[ ! "$PCRE_VER" =~ ^[0-9]+\.[0-9]+$ ]]
 then


### PR DESCRIPTION
Created a PR to update PCRE_DOWNLOAD_LINK to use the github download link since ftp.pcre.org is no longer available.

Please check it.

[From pcre.org](https://www.pcre.org/#:~:text=Note%20that%20the%20former%20ftp.pcre.org%20FTP%20site%20is%20no%20longer%20available.%20You%20will%20need%20to%20update%20any%20scripts%20that%20download%20PCRE%20source%20code%20to%20download%20via%20HTTPS%2C%20Git%2C%20or%20Subversion%20from%20the%20new%20home%20on%20GitHub%20instead.)
> Note that the former ftp.pcre.org FTP site is no longer available. You will need to update any scripts that download PCRE source code to download via HTTPS, Git, or Subversion from the new home on GitHub instead.
