### PR TITLE
Fixed the position of a double quotation mark in the command.

### DIFF
--- a/MacClam.sh
+++ b/MacClam.sh
@@ -600,7 +600,7 @@ if [ -t 0 ]
 then
     "$CLAMAV_INS/bin/freshclam" --config-file="$FRESHCLAM_CONF" || true
 else
-    "$CLAMAV_INS/bin/freshclam "--quiet --config-file="$FRESHCLAM_CONF" || true
+    "$CLAMAV_INS/bin/freshclam" --quiet --config-file="$FRESHCLAM_CONF" || true
 fi
 
 echo


### PR DESCRIPTION
It was probably a mistake in the command, but it was an error and I fixed it.